### PR TITLE
Add file compression with zstd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,3 +6,4 @@ add_executable(cshy
   src/shy_file.c
   )
 target_include_directories(cshy PUBLIC include/)
+target_link_libraries(cshy PUBLIC zstd)

--- a/include/shy_file.h
+++ b/include/shy_file.h
@@ -7,7 +7,6 @@
 typedef struct {
   uint32_t magic;
   uint64_t file_cnt;
-  uint64_t data_size;
   uint64_t str_size;
 } shy_hdr;
 
@@ -16,13 +15,14 @@ typedef struct {
   uint64_t off;
   uint64_t size;
   uint64_t path_off;
+  uint64_t unc_size; // Uncompressed size. No compression if 0.
+  uint8_t* data;
 } shy_entry;
 
 // Shy file format struct.
 typedef struct {
   shy_hdr header;
   shy_entry* entries;
-  uint8_t* data;
   char* paths;
 } shy_file;
 

--- a/include/shy_file.h
+++ b/include/shy_file.h
@@ -30,7 +30,7 @@ typedef struct {
 shy_file shy_file_read(const char* path);
 
 // Save SHY-File to disk.
-void shy_file_save(shy_file files, const char* path);
+void shy_file_save(shy_file files, const char* path, int clvl);
 
 // Create SHY-File memory representation.
 shy_file shy_file_create(const char** file_paths, size_t file_cnt);

--- a/src/main.c
+++ b/src/main.c
@@ -8,12 +8,16 @@ int main(int argc, const char** argv) {
   size_t fileCount = 0;
   const char** inputFiles = calloc(fileCap, sizeof(char*));
   const char* outputFile = NULL;
+  int clvl = 14;
 
   if (argc < 3) {
-    printf("Usage: cshy <operation> <filepath1> [filepath2] [...] -o <outputFileName>\n");
+    printf("Usage: cshy <operation> <filepath1> [filepath2] [...] -o <outputFileName> -c <compressionLevel>\n");
     printf("Operations:\n");
     printf("\tpack - Packs the specified files into a .shy file.\n");
     printf("\tunpack - Unpacks a .shy-file.");
+    printf("\nOptions:\n");
+    printf("\t-o - Specify the name of your .shy-archive.\n");
+    printf("\t-c - Specify compression level. (Standard: %i)\n\tPossible compression options: 1 - 20.\n\tZstd \'--ultra\' compression (level > 20) not supported.\n", clvl);
     printf("\nExample:\n");
     printf("\tcshy pack file1.txt file2.txt\n");
     printf("\tcshy unpack archvie.shy\n");
@@ -23,6 +27,13 @@ int main(int argc, const char** argv) {
   for (int i = 2; i < argc; i++) {
     if (!strcmp(argv[i], "-o")) {
       outputFile = argv[++i];
+    } else if (!strcmp(argv[i], "-c")) {
+      int arg = atoi(argv[++i]);
+      if (arg > 20 | arg < 1) {
+        printf("Invalid compression level! Valid levels range from 1 to 20.\n");
+        exit(1);
+      }
+      clvl = arg;
     } else {
       // This is essentially array.push()
       inputFiles[fileCount] = argv[i];
@@ -45,7 +56,7 @@ int main(int argc, const char** argv) {
     char nameBuff[512];
 
     snprintf(nameBuff, sizeof(nameBuff), "%s.shy", outputFile);
-    shy_file_save(file, nameBuff);
+    shy_file_save(file, nameBuff, clvl);
 
   } else if (!strcmp(argv[1], "unpack")) {
     if (argc > 3) {
@@ -57,6 +68,7 @@ int main(int argc, const char** argv) {
     printf("Writing Files.\n");
     shy_file_unpack(file, outputFile);
   }
-
+  
+  printf("Done.\n");
   return 0;
 }

--- a/src/shy_file.c
+++ b/src/shy_file.c
@@ -70,7 +70,7 @@ shy_file shy_file_read(const char* path) {
   return result;
 }
 
-void shy_file_save(shy_file files, const char* path) {
+void shy_file_save(shy_file files, const char* path, int clvl) {
   FILE* f = fopen(path, "w");
 
   if (!f) {
@@ -90,8 +90,9 @@ void shy_file_save(shy_file files, const char* path) {
   uint8_t** file_bodies = calloc(files.header.file_cnt, sizeof(uint8_t*));
 
   for (uint64_t i = 0; i < files.header.file_cnt; i++) {
+    printf("Compressing files with compression level '%i'. File %lu/%lu...\n", clvl, i+1, files.header.file_cnt);
     file_bodies[i] = calloc(ZSTD_compressBound(files.entries[i].unc_size), sizeof(uint8_t));
-    size_t err = ZSTD_compress(file_bodies[i], ZSTD_compressBound(files.entries[i].unc_size), files.entries[i].data,files.entries[i].unc_size, 14);
+    size_t err = ZSTD_compress(file_bodies[i], ZSTD_compressBound(files.entries[i].unc_size), files.entries[i].data,files.entries[i].unc_size, clvl);
    
     if (ZSTD_isError(err)) {
       printf("Error while trying to compress source files! %s! (line: %i)\n", ZSTD_getErrorName(err), __LINE__);


### PR DESCRIPTION
Compress all src files' content when packing the `.shy` file.
To accomplish this, the `zstd` lib was used instead of `zlib`.

TODO:

- [x] Add file compression
- [x] Allow User to specify compression level (default: `14`)
- [x] Check Error handling